### PR TITLE
remove unnecessary code

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = function debounce(func, wait, immediate){
       timeout = null;
       if (!immediate) {
         result = func.apply(context, args);
-        if (!timeout) context = args = null;
+        context = args = null;
       }
     }
   };


### PR DESCRIPTION
Because 
```js
  timeout = null
```
so `if(!timeout)` always be true, it's unnecessary