### PR TITLE
Fixes #3 - Debounced function executing early?

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function debounce(func, wait, immediate){
   function later() {
     var last = Date.now() - timestamp;
 
-    if (last < wait && last > 0) {
+    if (last < wait && last >= 0) {
       timeout = setTimeout(later, wait - last);
     } else {
       timeout = null;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "1.0.1",
   "repository": "git://github.com/component/debounce",
   "main": "index.js",
+  "scripts": {
+    "test": "minijasminenode test.js"
+  },
   "license": "MIT",
   "keywords": [
     "function",
@@ -11,6 +14,8 @@
     "invoke"
   ],
   "devDependencies": {
+    "minijasminenode": "^1.1.1",
+    "sinon": "^1.17.7",
     "mocha": "*",
     "should": "*"
   },

--- a/test.js
+++ b/test.js
@@ -1,0 +1,44 @@
+var debounce = require('.')
+var sinon = require('sinon')
+
+describe('housekeeping', function() {
+  it('should be defined as a function', function() {
+    expect(typeof debounce).toEqual('function')
+  })
+})
+
+describe('catch issue #3 - Debounced function executing early?', function() {
+
+  // use sinon to control the clock
+  var clock
+
+  beforeEach(function(){
+    clock = sinon.useFakeTimers()
+  })
+
+  afterEach(function(){
+    clock.restore()
+  })
+
+  it('should debounce with fast timeout', function() {
+
+    var callback = sinon.spy()
+
+    // set up debounced function with wait of 100
+    var fn = debounce(callback, 100)
+
+    // call debounced function at interval of 50
+    setTimeout(fn, 100)
+    setTimeout(fn, 150)
+    setTimeout(fn, 200)
+    setTimeout(fn, 250)
+
+    // set the clock to 100 (perioid of the wait) ticks after the last debounced call
+    clock.tick(350)
+
+    // the callback should have been triggered once
+    expect(callback.callCount).toEqual(1)
+
+  })
+
+})

--- a/test.js
+++ b/test.js
@@ -33,7 +33,7 @@ describe('catch issue #3 - Debounced function executing early?', function() {
     setTimeout(fn, 200)
     setTimeout(fn, 250)
 
-    // set the clock to 100 (perioid of the wait) ticks after the last debounced call
+    // set the clock to 100 (period of the wait) ticks after the last debounced call
     clock.tick(350)
 
     // the callback should have been triggered once


### PR DESCRIPTION
Added failing test case in one commit, and fix in second commit.

Requires dependencies (minijasminenode and sinon) to be installed via `npm install` and then run `npm test` to run unit tests.
