### PR TITLE
Ability to force execution

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,10 +29,9 @@ To later clear the timer and cancel currently scheduled executions:
 window.onresize.clear();
 ```
 
-To force the function to execute immediately and reset the timer for
-any future invocations:
+To execute any pending invocations and reset the timer:
 ```
-window.onresize.force();
+window.onresize.flush();
 ```
 
 ## API
@@ -51,7 +50,7 @@ window.onresize.force();
   The debounced function returned has a property 'clear' that is a 
   function that will clear any scheduled future executions of your function.
 
-  The debounced function returned has a property 'force' that is a 
+  The debounced function returned has a property 'flush' that is a 
   function that will immediately execute the function if execution is scheduled,
   and reset the execution timer for subsequent invocations of the debounced
   function.

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,8 @@
 
 # debounce
 
-  Useful for implementing behavior that should only happen after a repeated action has completed.
+  Useful for implementing behavior that should only happen after a repeated
+  action has completed.
 
 ## Installation
 
@@ -28,15 +29,32 @@ To later clear the timer and cancel currently scheduled executions:
 window.onresize.clear();
 ```
 
+To force the function to execute immediately and reset the timer for
+any future invocations:
+```
+window.onresize.force();
+```
+
 ## API
 
 ### debounce(fn, wait, [ immediate || false ])
 
-  Creates and returns a new debounced version of the passed function that will postpone its execution until after wait milliseconds have elapsed since the last time it was invoked.
+  Creates and returns a new debounced version of the passed function that
+  will postpone its execution until after wait milliseconds have elapsed
+  since the last time it was invoked.
 
-  Pass `true` for the `immediate` parameter to cause debounce to trigger the function on the leading edge instead of the trailing edge of the wait interval. Useful in circumstances like preventing accidental double-clicks on a "submit" button from firing a second time.
+  Pass `true` for the `immediate` parameter to cause debounce to trigger
+  the function on the leading edge instead of the trailing edge of the wait
+  interval. Useful in circumstances like preventing accidental double-clicks
+  on a "submit" button from firing a second time.
 
-  The debounced function returned also has a property 'clear' that is a function that will clear any scheduled future executions of your function.
+  The debounced function returned has a property 'clear' that is a 
+  function that will clear any scheduled future executions of your function.
+
+  The debounced function returned has a property 'force' that is a 
+  function that will immediately execute the function if execution is scheduled,
+  and reset the execution timer for subsequent invocations of the debounced
+  function.
 
 ## License
 

--- a/Readme.md
+++ b/Readme.md
@@ -51,7 +51,7 @@ window.onresize.flush();
   function that will clear any scheduled future executions of your function.
 
   The debounced function returned has a property 'flush' that is a 
-  function that will immediately execute the function if execution is scheduled,
+  function that will immediately execute the function if and only if execution is scheduled,
   and reset the execution timer for subsequent invocations of the debounced
   function.
 

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = function debounce(func, wait, immediate){
     }
   };
   
-  debounced.force = function() {
+  debounced.flush = function() {
     if (timeout) {
       result = func.apply(context, args);
       context = args = null;

--- a/index.js
+++ b/index.js
@@ -51,6 +51,16 @@ module.exports = function debounce(func, wait, immediate){
       timeout = null;
     }
   };
+  
+  debounced.force = function() {
+    if (timeout) {
+      result = func.apply(context, args);
+      context = args = null;
+      
+      clearTimeout(timeout);
+      timeout = null;
+    }
+  };
 
   return debounced;
 };

--- a/test.js
+++ b/test.js
@@ -42,3 +42,129 @@ describe('catch issue #3 - Debounced function executing early?', function() {
   })
 
 })
+
+describe('forcing execution', function() {
+
+  // use sinon to control the clock
+  var clock
+
+  beforeEach(function(){
+    clock = sinon.useFakeTimers()
+  })
+
+  afterEach(function(){
+    clock.restore()
+  })
+
+  it('should not execute prior to timeout', function() {
+
+    var callback = sinon.spy()
+
+    // set up debounced function with wait of 100
+    var fn = debounce(callback, 100)
+
+    // call debounced function at interval of 50
+    setTimeout(fn, 100)
+    setTimeout(fn, 150)
+
+    // set the clock to 25 (period of the wait) ticks after the last debounced call
+    clock.tick(175)
+
+    // the callback should not have been called yet
+    expect(callback.callCount).toEqual(0)
+
+  })
+
+  it('should execute prior to timeout when forced', function() {
+
+    var callback = sinon.spy()
+
+    // set up debounced function with wait of 100
+    var fn = debounce(callback, 100)
+
+    // call debounced function at interval of 50
+    setTimeout(fn, 100)
+    setTimeout(fn, 150)
+
+    // set the clock to 25 (period of the wait) ticks after the last debounced call
+    clock.tick(175)
+    
+    fn.force()
+
+    // the callback has been called
+    expect(callback.callCount).toEqual(1)
+
+  })
+
+  it('should not execute again after timeout when forced before the timeout', function() {
+
+    var callback = sinon.spy()
+
+    // set up debounced function with wait of 100
+    var fn = debounce(callback, 100)
+
+    // call debounced function at interval of 50
+    setTimeout(fn, 100)
+    setTimeout(fn, 150)
+
+    // set the clock to 25 (period of the wait) ticks after the last debounced call
+    clock.tick(175)
+    
+    fn.force()
+    
+    // the callback has been called here
+    expect(callback.callCount).toEqual(1)
+    
+    // move to past the timeout
+    clock.tick(225)
+
+    // the callback should have only been called once
+    expect(callback.callCount).toEqual(1)
+
+  })
+
+  it('should not execute on a timer after being forced', function() {
+
+    var callback = sinon.spy()
+
+    // set up debounced function with wait of 100
+    var fn = debounce(callback, 100)
+
+    // call debounced function at interval of 50
+    setTimeout(fn, 100)
+    setTimeout(fn, 150)
+
+    // set the clock to 25 (period of the wait) ticks after the last debounced call
+    clock.tick(175)
+    
+    fn.force()
+    
+    // the callback has been called here
+    expect(callback.callCount).toEqual(1)
+    
+    // schedule again
+    setTimeout(fn, 250)
+    
+    // move to past the new timeout
+    clock.tick(400)
+
+    // the callback should have been called again
+    expect(callback.callCount).toEqual(2)
+
+  })
+
+  it('should not execute when forced if nothing was scheduled', function() {
+
+    var callback = sinon.spy()
+
+    // set up debounced function with wait of 100
+    var fn = debounce(callback, 100)
+
+    fn.force()
+    
+    // the callback should not have been called
+    expect(callback.callCount).toEqual(0)
+
+  })
+
+})

--- a/test.js
+++ b/test.js
@@ -75,7 +75,7 @@ describe('forcing execution', function() {
 
   })
 
-  it('should execute prior to timeout when forced', function() {
+  it('should execute prior to timeout when flushed', function() {
 
     var callback = sinon.spy()
 
@@ -89,14 +89,14 @@ describe('forcing execution', function() {
     // set the clock to 25 (period of the wait) ticks after the last debounced call
     clock.tick(175)
     
-    fn.force()
+    fn.flush()
 
     // the callback has been called
     expect(callback.callCount).toEqual(1)
 
   })
 
-  it('should not execute again after timeout when forced before the timeout', function() {
+  it('should not execute again after timeout when flushed before the timeout', function() {
 
     var callback = sinon.spy()
 
@@ -110,7 +110,7 @@ describe('forcing execution', function() {
     // set the clock to 25 (period of the wait) ticks after the last debounced call
     clock.tick(175)
     
-    fn.force()
+    fn.flush()
     
     // the callback has been called here
     expect(callback.callCount).toEqual(1)
@@ -123,7 +123,7 @@ describe('forcing execution', function() {
 
   })
 
-  it('should not execute on a timer after being forced', function() {
+  it('should not execute on a timer after being flushed', function() {
 
     var callback = sinon.spy()
 
@@ -137,7 +137,7 @@ describe('forcing execution', function() {
     // set the clock to 25 (period of the wait) ticks after the last debounced call
     clock.tick(175)
     
-    fn.force()
+    fn.flush()
     
     // the callback has been called here
     expect(callback.callCount).toEqual(1)
@@ -153,14 +153,14 @@ describe('forcing execution', function() {
 
   })
 
-  it('should not execute when forced if nothing was scheduled', function() {
+  it('should not execute when flushed if nothing was scheduled', function() {
 
     var callback = sinon.spy()
 
     // set up debounced function with wait of 100
     var fn = debounce(callback, 100)
 
-    fn.force()
+    fn.flush()
     
     // the callback should not have been called
     expect(callback.callCount).toEqual(0)


### PR DESCRIPTION
This PR adds an option to force execution of any scheduled invocations.

Use case: I have a map that the user can move around, and the center is updated on the server with each move. This update is debounced. The user can also load a different object into the map in which case I want to immediately flush pending moves for the old object.
