### PR TITLE
Allowed setTimeout and Date.now to be passed to debounce

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,6 +47,18 @@ window.onresize.flush();
   interval. Useful in circumstances like preventing accidental double-clicks
   on a "submit" button from firing a second time.
 
+  Pass a function for the `scheduler` parameter to called to delay functions.
+  This defaults to `setTimeout` and should behave similarly.
+
+  ```js
+  var method = function () {
+    console.log('Debounced!');
+  };
+
+  debounce(method, 100);
+  debounce(method, 100, true);
+```
+
   The debounced function returned has a property 'clear' that is a 
   function that will clear any scheduled future executions of your function.
 
@@ -54,6 +66,41 @@ window.onresize.flush();
   function that will immediately execute the function if and only if execution is scheduled,
   and reset the execution timer for subsequent invocations of the debounced
   function.
+
+### debounce(fn, wait, { getTimestamp?, immediate?, scheduler? })
+
+  Same first two parameters `fn` and `wait` as before, but passing an object containing `getTimestamp` and/or `immediate` and/or `scheduler`.
+
+  If the object contains `immediate`, it's used as before.
+
+  If the object contains `getTimestamp`, it's used instead of `Date.now` to create current timestamps.
+  It should be a function that returns a numeric timestamp.
+
+  If the object contains `scheduler`, it's used instead of `setTimeout` to delay function executions.
+  It should be a function that takes a function and a millisecond delay as a number.
+
+  ```js
+  var getTimestamp = function () {
+    var now = Date.now();
+    console.log('Found time', now);
+    return now;
+  };
+
+  debounce(method, 100, {
+    getTimestamp: getTimestamp,
+  });
+
+  var scheduler = function (callback, delay) {
+    console.log('Calling', callback, 'in', delay, 'ms');
+    setTimeout(callback, delay);
+  }
+
+  debounce(method, 100, true, {
+    getTimestamp: getTimestamp,
+    scheduler: scheduler,
+    wait: true,
+  });
+  ```
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -13,15 +13,24 @@
  * @api public
  */
 
-module.exports = function debounce(func, wait, immediate){
-  var timeout, args, context, timestamp, result;
+module.exports = function debounce(func, wait, immediate) {
+  var timeout, args, context, timestamp, result, getTimestamp, scheduler;
+
+  if (immediate != null && typeof immediate === "object") {
+    immediate = immediate.immediate;
+    getTimestamp = immediate.getTimestamp;
+    scheduler = immediate.scheduler;
+  }
+
   if (null == wait) wait = 100;
+  if (null == scheduler) scheduler = setTimeout;
+  if (null == getTimestamp) getTimestamp = function () { return Date.now(); };
 
   function later() {
-    var last = Date.now() - timestamp;
+    var last = getTimestamp() - timestamp;
 
     if (last < wait && last >= 0) {
-      timeout = setTimeout(later, wait - last);
+      timeout = scheduler(later, wait - last);
     } else {
       timeout = null;
       if (!immediate) {
@@ -34,9 +43,9 @@ module.exports = function debounce(func, wait, immediate){
   var debounced = function(){
     context = this;
     args = arguments;
-    timestamp = Date.now();
+    timestamp = getTimestamp();
     var callNow = immediate && !timeout;
-    if (!timeout) timeout = setTimeout(later, wait);
+    if (!timeout) timeout = scheduler(later, wait);
     if (callNow) {
       result = func.apply(context, args);
       context = args = null;


### PR DESCRIPTION
If immediate is a non-null object, it's used as a settings object that can provide a `scheduler` (defaulted to `setTimeout`) and `getTimestamp` (defaulted to `Date.now`).

Note: this is technically a breaking change, as a non-boolean truthy `immediate` used to count as a boolean.

Fixes #22.